### PR TITLE
"main"を正しくする / 型定義を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jskawari",
   "version": "1.0.0",
   "description": "華和梨の JavaScript によるサブセット再実装 / subset of pseudo AI module 'KAWARI' implemented by JavaScript",
-  "main": "index.js",
+  "main": "build/jskawari.js",
   "scripts": {
     "test": "node ./test/test.js",
     "build": "rm ./build/*.* && tsc"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "華和梨の JavaScript によるサブセット再実装 / subset of pseudo AI module 'KAWARI' implemented by JavaScript",
   "main": "build/jskawari.js",
+  "types": "build/jskawari.d.ts",
   "scripts": {
     "test": "node ./test/test.js",
     "build": "rm ./build/*.* && tsc"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "declaration": true,
         "strict": true,
         "target": "ES2020",
         "module": "CommonJS",


### PR DESCRIPTION
"main"がcommonjsでのデフォルトモジュールファイルを定め、"types"が対応するTypeScript型定義を参照する。

型定義そのもののファイルに関しては別のプルリク（ #4 ）によって内容が変わるため、ここではコミットしていない。
なので改めてbuildしてbuild/jskawari.d.tsをつくる必要がある。
（そもそもnpm moduleにする場合ビルド後のファイルをgitに含めないほうがなにかと便利だったりもするが）