### PR TITLE
export defaultあるいはexport { foo }のほうが将来的な互換性に有利

### DIFF
--- a/build/jskawari.js
+++ b/build/jskawari.js
@@ -1,4 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 function jskawari() {
     // 単語集合：エントリに所属する全ての単語の集合で重複なし。単語をindexOfした結果が単語IDとなり、辞書配列に格納される。
     const wordcollection = [];
@@ -218,4 +219,5 @@ function jskawari() {
         },
     };
 }
-module.exports = jskawari;
+// エクスポート設定
+exports.default = jskawari;

--- a/src/jskawari.ts
+++ b/src/jskawari.ts
@@ -215,4 +215,4 @@ function jskawari() {
     };
 }
 // エクスポート設定
-export = jskawari;
+export default jskawari;

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-var jskawari = require('../build/jskawari');
+var { default: jskawari } = require('../build/jskawari');
 var dic = jskawari();
 
 // * 単語登録の方法(insert)


### PR DESCRIPTION
ES Modulesが興隆しており、`export = foo`形式はそちらではサポートされないため。

`export function jskawari() {}`でもよいがとりあえずdefault exportを採用