### PR TITLE
定番dependencyを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+package-lock.json
 .vscode/

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/satos/jskawari/issues"
   },
-  "homepage": "https://github.com/satos/jskawari#readme"
+  "homepage": "https://github.com/satos/jskawari#readme",
+  "devDependencies": {
+    "typescript": "^4.2.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
     "test": "node ./test/test.js",
-    "build": "rimraf ./build/*.* && tsc"
+    "build": "npm-run-all clean tsc",
+    "tsc": "tsc",
+    "clean": "rimraf ./build/*.*"
   },
   "repository": {
     "type": "git",
@@ -22,6 +24,7 @@
   },
   "homepage": "https://github.com/satos/jskawari#readme",
   "devDependencies": {
+    "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
     "typescript": "^4.2.4"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test",
     "test": "node ./test/test.js",
-    "build": "rm ./build/*.* && tsc"
+    "build": "rimraf ./build/*.* && tsc"
   },
   "repository": {
     "type": "git",
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/satos/jskawari#readme",
   "devDependencies": {
+    "rimraf": "^3.0.2",
     "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
- ビルドに必要なtypescript
- rm -rfはWindowsでは使えないためクロスプラットフォームのrimraf
- &&でつなぐよりnpm-run-allのほうが見通しが良い
- npm installで作られるpackage-lock.jsonはコミットしない
  - 将来的にCIなどでテストするとき古いパッケージに依存しないべきなので