### PR TITLE
ECMAScript modulesもビルドする

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 build
+esm

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 .vscode/
+esm

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules
 build
+esm
 package.json
 package-lock.json
 *.md

--- a/package.json
+++ b/package.json
@@ -4,13 +4,25 @@
   "description": "華和梨の JavaScript によるサブセット再実装 / subset of pseudo AI module 'KAWARI' implemented by JavaScript",
   "main": "build/jskawari.js",
   "types": "build/jskawari.d.ts",
+  "exports": {
+    "import": "./esm/jskawari.mjs",
+    "require": "./build/jskawari.js",
+    "node": "./esm/jskawari.mjs",
+    "default": "./build/jskawari.js"
+  },
   "scripts": {
     "prepare": "npm run build",
     "prepublishOnly": "npm-run-all prettier:check eslint:check test",
     "test": "node ./test/test.js",
-    "build": "npm-run-all clean tsc",
-    "tsc": "tsc",
-    "clean": "rimraf ./build/*.*",
+    "build": "npm-run-all --parallel cjs esm",
+    "clean": "npm-run-all --parallel cjs:clean esm:clean",
+    "cjs": "npm-run-all cjs:clean cjs:tsc",
+    "cjs:tsc": "tsc",
+    "cjs:clean": "rimraf ./build",
+    "esm": "npm-run-all esm:clean esm:tsc esm:rename",
+    "esm:tsc": "tsc --project tsconfig.esm.json",
+    "esm:rename": "shx mv esm/jskawari.js esm/jskawari.mjs",
+    "esm:clean": "rimraf ./esm",
     "eslint:check": "eslint . --ext .js,.jsx,.ts,.tsx",
     "eslint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "prettier:check": "prettier --check .",
@@ -36,6 +48,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
+    "shx": "^0.3.3",
     "typescript": "^4.2.4"
   }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "module": "ES2020",
+        "outDir": "./esm"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
         "esModuleInterop": true,
         "outDir": "./build"
     },
-    "exclude": ["node_modules", "build"]
+    "exclude": ["node_modules", "build", "esm"]
 }


### PR DESCRIPTION
これだけで一応ブラウザ対応にもなる。

- ecmascript modules形式のファイルはnode.jsでは.mjs拡張子にすることになっている。
- tscは.mjsというファイル名を吐いてくれないためクロスプラットフォームにshコマンドが使えるshxを導入しmvする
- esmは一応コミットしない形式に
- ブラウザでの読み込みは https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Modules を参照